### PR TITLE
Add set_active_param_names. compute norm.

### DIFF
--- a/include/caffe/apollonet.hpp
+++ b/include/caffe/apollonet.hpp
@@ -93,6 +93,12 @@ class ApolloNet {
   inline const set<string>& active_param_names() const {
     return active_params_set_;
   }
+  inline void set_active_param_names(const vector<string>& active_params_vec) {
+    active_params_set_.clear();
+    for (int i = 0; i < active_params_vec.size(); ++i) {
+      active_params_set_.insert(active_params_vec[i]);
+    }
+  }
 
  protected:
   /// @brief The phase: TRAIN or TEST

--- a/python/apollocaffe/cpp/_apollocaffe.pyx
+++ b/python/apollocaffe/cpp/_apollocaffe.pyx
@@ -78,6 +78,8 @@ cdef class Tensor:
         return self.thisptr.get().count()
     def dot(self, other):
         return self.DotPFrom(other)
+    def norm(self):
+        return self.dot(self) ** 0.5
     def cosine(self, other):
         num = self.dot(other) 
         denom = (self.dot(self) * other.dot(other)) ** 0.5
@@ -320,6 +322,14 @@ cdef class ApolloNet:
     def backward(self):
         for layer_name in self.active_layer_names()[::-1]:
             self.backward_layer(layer_name)
+    def print_norm(self, param_set=None, label=None):
+        if label != None:
+            print label
+        params = self.params
+        if param_set is None:
+            param_set = self.active_param_names()
+        for param_name in param_set:
+            print "  ", param_name, ", data=", params[param_name].data_tensor.norm(), ", diff=", params[param_name].diff_tensor.norm() 
     def update(self, lr, momentum=0., clip_gradients=-1, weight_decay=0., param_set=None):
         diffnorm = self.diff_l2_norm() 
         clip_scale = 1.

--- a/python/apollocaffe/cpp/definitions.pxd
+++ b/python/apollocaffe/cpp/definitions.pxd
@@ -92,6 +92,7 @@ cdef extern from "caffe/apollonet.hpp" namespace "caffe":
         void SaveTrainedLayersTo(string trained_filename) except + 
         vector[string]& active_layer_names()
         set[string]& active_param_names()
+        void set_active_param_names(vector[string]&)
 
 cdef extern from "caffe/layer_factory.hpp" namespace "caffe::LayerRegistry<float>":
     cdef shared_ptr[Layer] CreateLayer(LayerParameter& param)

--- a/src/caffe/layers/lstm_unit_layer.cpp
+++ b/src/caffe/layers/lstm_unit_layer.cpp
@@ -43,7 +43,8 @@ void LstmUnitLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       << "lstm_unit_param.has_output_gate_weight_filler()";
 
   channels_ = lstm_unit_param.num_cells();
-  CHECK_EQ(channels_, bottom[1]->shape(1)) << "Number of input memory channels must match the number of lstm mem_cells";
+  CHECK_EQ(channels_, bottom[1]->shape(1)) <<
+    "Number of input memory channels must match the number of lstm mem_cells";
   input_data_size_ = bottom[0]->shape(1);
   num_ = bottom[0]->shape(0);
   M_ = num_;
@@ -281,7 +282,8 @@ void LstmUnitLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       (Dtype)1., input_diff);
   }
 
-  caffe_mul(num_ * channels_, output_gates_diff, tanh_next_memory_state, dldg_data);
+  caffe_mul(num_ * channels_, output_gates_diff, tanh_next_memory_state,
+      dldg_data);
   caffe_mul(num_ * channels_, next_hidden_state_diff, dldg_data, dldg_data);
   caffe_cpu_gemm<Dtype>(CblasTrans, CblasNoTrans,
     channels_, input_data_size_, num_,


### PR DESCRIPTION
Give users more control over the active_params_set in apollonet.hpp.
Also added useful methods to compute norms and print norms in _apollocaffe.pyx.